### PR TITLE
Update configuration files for Firebase hosting and Svelte adapter

### DIFF
--- a/frontend/.firebaserc
+++ b/frontend/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "osc-directory"
+  }
+}

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -5,6 +5,8 @@
 .wrangler
 /.svelte-kit
 /build
+public
+
 
 # OS
 .DS_Store
@@ -19,3 +21,6 @@ Thumbs.db
 # Vite
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# Firebase
+.firebase

--- a/frontend/firebase.json
+++ b/frontend/firebase.json
@@ -1,0 +1,23 @@
+{
+	"hosting": {
+		"public": "public",
+		"ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+		"rewrites": [
+			{
+				"source": "**",
+				"destination": "/index.html"
+			}
+		],
+		"headers": [
+			{
+				"source": "**/*.@(js|css)",
+				"headers": [
+					{
+						"key": "Cache-Control",
+						"value": "public, max-age=31536000"
+					}
+				]
+			}
+		]
+	}
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,12 +18,14 @@
 		"add-example": "tsx scripts/add-example-project.ts",
 		"update-metadata": "tsx scripts/update-metadata.ts",
 		"generate-readme": "tsx scripts/generate-readme-tables.ts",
-		"parse-template": "tsx scripts/parse-template.ts"
+		"parse-template": "tsx scripts/parse-template.ts",
+		"deploy": "vite build && firebase deploy --only hosting"
 	},
 	"devDependencies": {
 		"@eslint/compat": "^1.2.5",
 		"@eslint/js": "^9.18.0",
 		"@sveltejs/adapter-auto": "^6.0.0",
+		"@sveltejs/adapter-static": "^3.0.8",
 		"@sveltejs/kit": "^2.16.0",
 		"@sveltejs/vite-plugin-svelte": "^5.0.0",
 		"@tailwindcss/typography": "^0.5.15",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -21,6 +21,9 @@ importers:
       '@sveltejs/adapter-auto':
         specifier: ^6.0.0
         version: 6.0.1(@sveltejs/kit@2.21.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.31.1)(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)))(svelte@5.31.1)(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)))
+      '@sveltejs/adapter-static':
+        specifier: ^3.0.8
+        version: 3.0.8(@sveltejs/kit@2.21.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.31.1)(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)))(svelte@5.31.1)(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)))
       '@sveltejs/kit':
         specifier: ^2.16.0
         version: 2.21.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.31.1)(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)))(svelte@5.31.1)(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4))
@@ -556,6 +559,11 @@ packages:
 
   '@sveltejs/adapter-auto@6.0.1':
     resolution: {integrity: sha512-mcWud3pYGPWM2Pphdj8G9Qiq24nZ8L4LB7coCUckUEy5Y7wOWGJ/enaZ4AtJTcSm5dNK1rIkBRoqt+ae4zlxcQ==}
+    peerDependencies:
+      '@sveltejs/kit': ^2.0.0
+
+  '@sveltejs/adapter-static@3.0.8':
+    resolution: {integrity: sha512-YaDrquRpZwfcXbnlDsSrBQNCChVOT9MGuSg+dMAyfsAa1SmiAhrA5jUYUiIMC59G92kIbY/AaQOWcBdq+lh+zg==}
     peerDependencies:
       '@sveltejs/kit': ^2.0.0
 
@@ -2204,6 +2212,10 @@ snapshots:
       acorn: 8.14.1
 
   '@sveltejs/adapter-auto@6.0.1(@sveltejs/kit@2.21.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.31.1)(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)))(svelte@5.31.1)(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)))':
+    dependencies:
+      '@sveltejs/kit': 2.21.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.31.1)(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)))(svelte@5.31.1)(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4))
+
+  '@sveltejs/adapter-static@3.0.8(@sveltejs/kit@2.21.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.31.1)(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)))(svelte@5.31.1)(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)))':
     dependencies:
       '@sveltejs/kit': 2.21.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.31.1)(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4)))(svelte@5.31.1)(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.4))
 

--- a/frontend/svelte.config.js
+++ b/frontend/svelte.config.js
@@ -1,4 +1,5 @@
-import adapter from '@sveltejs/adapter-auto';
+import adapter from '@sveltejs/adapter-static';
+// import adapter from '@sveltejs/adapter-auto'; // Uncomment this line if you want to use adapter-auto (Vercel, Netlify, etc.)
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 /** @type {import('@sveltejs/kit').Config} */
@@ -11,7 +12,13 @@ const config = {
 		// adapter-auto only supports some environments, see https://svelte.dev/docs/kit/adapter-auto for a list.
 		// If your environment is not supported, or you settled on a specific environment, switch out the adapter.
 		// See https://svelte.dev/docs/kit/adapters for more information about adapters.
-		adapter: adapter(),
+		adapter: adapter({
+			pages: 'public',
+			assets: 'public',
+			fallback: 'index.html',
+			precompress: false,
+			strict: true
+		}),
 		alias: {
 			$shared: '../shared/'
 		}


### PR DESCRIPTION
This pull request introduces Firebase hosting configuration and updates the SvelteKit setup to use the `@sveltejs/adapter-static` for static site generation. Additionally, it includes updates to the `.gitignore` file and adds a new deployment script. Below is a breakdown of the most important changes:

### Firebase Hosting Configuration:
* Added `firebase.json` to configure Firebase hosting, specifying the `public` directory for static files, cache-control headers for assets, and rewrites for SPA routing.
* Created `.firebaserc` to define the default Firebase project as `osc-directory`.

### SvelteKit Adapter Update:
* Switched from `@sveltejs/adapter-auto` to `@sveltejs/adapter-static` in `svelte.config.js`, with additional configuration for static site generation, including `pages`, `assets`, and `fallback`. [[1]](diffhunk://#diff-766f382f05f04d7550c6437e011b605aabe0868165c358bed76ce313aa5b9924L1-R2) [[2]](diffhunk://#diff-766f382f05f04d7550c6437e011b605aabe0868165c358bed76ce313aa5b9924L14-R21)
* Updated `pnpm-lock.yaml` and `package.json` to include `@sveltejs/adapter-static` as a dependency. [[1]](diffhunk://#diff-41b1ff3a74ba81fa74c8dd225d66d81573be3f2990e1d98b9b09798b147d40a8R24-R26) [[2]](diffhunk://#diff-41b1ff3a74ba81fa74c8dd225d66d81573be3f2990e1d98b9b09798b147d40a8R565-R569) [[3]](diffhunk://#diff-41b1ff3a74ba81fa74c8dd225d66d81573be3f2990e1d98b9b09798b147d40a8R2218-R2221) [[4]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655L21-R28)

### Deployment and Build Process:
* Added a `deploy` script in `package.json` to build the project using Vite and deploy it to Firebase hosting.

### Git Ignore Updates:
* Updated `.gitignore` to include Firebase-related files (`.firebase`) and the `public` directory. [[1]](diffhunk://#diff-8e548ede50532796f028e75d8f3384d5bdb57b9fbe2bda95521774d0c46d0f97R8-R9) [[2]](diffhunk://#diff-8e548ede50532796f028e75d8f3384d5bdb57b9fbe2bda95521774d0c46d0f97R24-R26)