### PR TITLE
feat: enhance project sorting and grouping functionality with GitHub …

### DIFF
--- a/backend/data/projects.json
+++ b/backend/data/projects.json
@@ -504,31 +504,6 @@
     "frameworks": []
   },
   {
-    "name": "engine_web-ifc",
-    "description": "Reading and writing IFC files with Javascript, at native speeds.",
-    "url": "https://github.com/ThatOpen/engine_web-ifc",
-    "tags": [
-      "cpp",
-      "emscripten",
-      "ifc",
-      "javascript",
-      "wasm",
-      "webassembly"
-    ],
-    "stars": 769,
-    "forks": 227,
-    "lastUpdated": "2025-08-06T07:07:50Z",
-    "mainLanguage": "TypeScript",
-    "license": "MPL-2.0",
-    "openIssues": 79,
-    "platforms": [
-      "web"
-    ],
-    "frameworks": [
-      "nodejs"
-    ]
-  },
-  {
     "name": "IfcLCA",
     "description": "Opensource Life Cycle Assessment for Built Environment using Industry Foundation Classes",
     "url": "https://github.com/IfcLCA/IfcLCA",
@@ -566,30 +541,6 @@
     "mainLanguage": "TypeScript",
     "license": "AGPL-3.0",
     "openIssues": 0,
-    "platforms": [
-      "web"
-    ],
-    "frameworks": [
-      "threejs"
-    ]
-  },
-  {
-    "name": "web-ifc-viewer",
-    "description": "Graphics engine and toolkit for client applications.",
-    "url": "https://github.com/ThatOpen/web-ifc-viewer",
-    "tags": [
-      "3d",
-      "bim",
-      "geometry",
-      "ifc",
-      "threejs"
-    ],
-    "stars": 977,
-    "forks": 243,
-    "lastUpdated": "2025-07-19T14:49:34Z",
-    "mainLanguage": "JavaScript",
-    "license": "MIT",
-    "openIssues": 56,
     "platforms": [
       "web"
     ],

--- a/frontend/src/lib/components/directory/ProjectCard.svelte
+++ b/frontend/src/lib/components/directory/ProjectCard.svelte
@@ -6,6 +6,7 @@
 
 	// Limit metadata to max 4 items
 	const displayMetadata = project.tags?.slice(0, 4) || [];
+	let projectUserName = project.url.match(/github\.com\/([^\/]+)/)?.[1] || 'Unknown';
 	let isExpanded = $state(false);
 </script>
 
@@ -115,6 +116,11 @@
 					</a>
 				</div>
 			{/if}
+
+			<div class="flex items-center">
+				<Icon icon="solar:user-broken" class="w-4 h-4 mr-1"></Icon>
+				<span>{projectUserName}</span>
+			</div>
 		</div>
 		{#if project.lastUpdated}
 			<div class="text-gray-500 flex gap-1 items-center mt-1 text-sm">

--- a/frontend/src/lib/components/directory/ProjectSorting.svelte
+++ b/frontend/src/lib/components/directory/ProjectSorting.svelte
@@ -3,17 +3,23 @@
 	import Icon from '@iconify/svelte';
 
 	type SortableField = 'name' | 'stars' | 'updated';
+	type GroupByField = 'none' | 'username' | 'language';
+	type GroupedProjects = {
+		groupName: string;
+		projects: Project[];
+	}[];
 
 	let {
 		projects,
 		onSortChange
 	}: {
 		projects: Project[];
-		onSortChange: (sortedProjects: Project[]) => void;
+		onSortChange: (sortedProjects: Project[], groupedProjects: GroupedProjects) => void;
 	} = $props();
 
 	let sortBy: SortableField = $state('name');
 	let sortOrder: 'asc' | 'desc' = $state('asc');
+	let groupBy: GroupByField = $state('none');
 
 	function sortProjects(a: Project, b: Project): number {
 		let result = 0;
@@ -38,14 +44,70 @@
 		return sortOrder === 'desc' ? -result : result;
 	}
 
+	function groupProjects(projects: Project[]): {
+		flatProjects: Project[];
+		groupedProjects: GroupedProjects;
+	} {
+		if (groupBy === 'none') {
+			return { flatProjects: projects, groupedProjects: [] };
+		}
+
+		const groups = new Map<string, Project[]>();
+
+		projects.forEach((project) => {
+			let groupKey: string;
+
+			switch (groupBy) {
+				case 'username':
+					// Extract username from GitHub URL
+					if (project.url) {
+						const match = project.url.match(/github\.com\/([^\/]+)/);
+						groupKey = match ? match[1] : 'Unknown User';
+					} else {
+						groupKey = 'Unknown User';
+					}
+					break;
+				case 'language':
+					groupKey = project.mainLanguage || 'Unknown Language';
+					break;
+				default:
+					groupKey = 'Ungrouped';
+			}
+
+			if (!groups.has(groupKey)) {
+				groups.set(groupKey, []);
+			}
+			groups.get(groupKey)!.push(project);
+		});
+
+		// Sort groups by key
+		const sortedGroups = Array.from(groups.entries())
+			.sort(([a], [b]) => a.localeCompare(b))
+			.map(([groupName, groupProjects]) => ({
+				groupName,
+				projects: groupProjects.sort(sortProjects)
+			}));
+
+		const flatProjects = sortedGroups.flatMap((group) => group.projects);
+
+		return { flatProjects, groupedProjects: sortedGroups };
+	}
+
 	function applySorting() {
 		const sorted = [...projects].sort(sortProjects);
-		onSortChange(sorted);
+		const { flatProjects, groupedProjects } = groupProjects(sorted);
+		onSortChange(flatProjects, groupedProjects);
 	}
 
 	function handleSortChange(e: Event) {
 		const target = e.target as HTMLSelectElement;
 		sortBy = target.value as typeof sortBy;
+		applySorting();
+	}
+
+	function handleGroupChange(e: Event) {
+		const target = e.target as HTMLSelectElement;
+		groupBy = target.value as typeof groupBy;
 		applySorting();
 	}
 
@@ -64,28 +126,44 @@
 	});
 </script>
 
-<div class="flex items-center gap-4 mb-4">
-	<label for="sort-select" class="text-sm font-medium text-gray-700">Sort by:</label>
-	<select
-		id="sort-select"
-		onchange={handleSortChange}
-		class="border border-gray-300 rounded-md p-2 bg-white focus:outline-none focus:ring-2 focus:ring-blue-500"
-		value={sortBy}
-	>
-		<option value="name">Name</option>
-		<option value="stars">Stars</option>
-		<option value="updated">Last Updated</option>
-	</select>
+<div class="flex items-center gap-4 mb-4 flex-wrap">
+	<div class="flex items-center gap-2">
+		<label for="sort-select" class="text-sm font-medium text-gray-700">Sort by:</label>
+		<select
+			id="sort-select"
+			onchange={handleSortChange}
+			class="border border-gray-300 rounded-md p-2 bg-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+			value={sortBy}
+		>
+			<option value="name">Name</option>
+			<option value="stars">Stars</option>
+			<option value="updated">Last Updated</option>
+		</select>
 
-	<button
-		onclick={toggleSortOrder}
-		class="flex items-center gap-1 px-3 py-2 border border-gray-300 rounded-md bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500"
-		title={sortOrder === 'asc' ? 'Switch to descending' : 'Switch to ascending'}
-	>
-		<Icon
-			icon={sortOrder === 'asc' ? 'mdi:sort-ascending' : 'mdi:sort-descending'}
-			class="w-4 h-4"
-		/>
-		<span class="text-sm">{sortOrder === 'asc' ? 'Asc' : 'Desc'}</span>
-	</button>
+		<button
+			onclick={toggleSortOrder}
+			class="flex items-center gap-1 px-3 py-2 border border-gray-300 rounded-md bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500"
+			title={sortOrder === 'asc' ? 'Switch to descending' : 'Switch to ascending'}
+		>
+			<Icon
+				icon={sortOrder === 'asc' ? 'mdi:sort-ascending' : 'mdi:sort-descending'}
+				class="w-4 h-4"
+			/>
+			<span class="text-sm">{sortOrder === 'asc' ? 'Asc' : 'Desc'}</span>
+		</button>
+	</div>
+
+	<div class="flex items-center gap-2">
+		<label for="group-select" class="text-sm font-medium text-gray-700">Group by:</label>
+		<select
+			id="group-select"
+			onchange={handleGroupChange}
+			class="border border-gray-300 rounded-md p-2 bg-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+			value={groupBy}
+		>
+			<option value="none">None</option>
+			<option value="username">GitHub Username</option>
+			<option value="language">Programming Language</option>
+		</select>
+	</div>
 </div>

--- a/frontend/src/lib/components/ui/PlatformFrameworkFilters.svelte
+++ b/frontend/src/lib/components/ui/PlatformFrameworkFilters.svelte
@@ -1,203 +1,203 @@
 <script lang="ts">
-  import { PLATFORM_TAGS, FRAMEWORK_TAGS } from '$lib/platform-tags.js';
-  import type { PlatformTag, FrameworkTag } from '$lib/platform-tags.js';
+	import { PLATFORM_TAGS, FRAMEWORK_TAGS } from '$lib/platform-tags.js';
+	import type { PlatformTag, FrameworkTag } from '$lib/platform-tags.js';
 
-  export let selectedPlatforms: PlatformTag[] = [];
-  export let selectedFrameworks: FrameworkTag[] = [];
+	export let selectedPlatforms: PlatformTag[] = [];
+	export let selectedFrameworks: FrameworkTag[] = [];
 
-  function togglePlatform(platform: PlatformTag) {
-    if (selectedPlatforms.includes(platform)) {
-      selectedPlatforms = selectedPlatforms.filter(p => p !== platform);
-    } else {
-      selectedPlatforms = [...selectedPlatforms, platform];
-    }
-  }
+	function togglePlatform(platform: PlatformTag) {
+		if (selectedPlatforms.includes(platform)) {
+			selectedPlatforms = selectedPlatforms.filter((p) => p !== platform);
+		} else {
+			selectedPlatforms = [...selectedPlatforms, platform];
+		}
+	}
 
-  function toggleFramework(framework: FrameworkTag) {
-    if (selectedFrameworks.includes(framework)) {
-      selectedFrameworks = selectedFrameworks.filter(f => f !== framework);
-    } else {
-      selectedFrameworks = [...selectedFrameworks, framework];
-    }
-  }
+	function toggleFramework(framework: FrameworkTag) {
+		if (selectedFrameworks.includes(framework)) {
+			selectedFrameworks = selectedFrameworks.filter((f) => f !== framework);
+		} else {
+			selectedFrameworks = [...selectedFrameworks, framework];
+		}
+	}
 
-  function clearPlatforms() {
-    selectedPlatforms = [];
-  }
+	function clearPlatforms() {
+		selectedPlatforms = [];
+	}
 
-  function clearFrameworks() {
-    selectedFrameworks = [];
-  }
+	function clearFrameworks() {
+		selectedFrameworks = [];
+	}
 </script>
 
 <div class="filter-section">
-  <div class="filter-group">
-    <div class="filter-header">
-      <h3 class="filter-title">
-        <span class="filter-icon">💻</span>
-        Platforms
-      </h3>
-      {#if selectedPlatforms.length > 0}
-        <button class="clear-btn" on:click={clearPlatforms}>Clear</button>
-      {/if}
-    </div>
-    
-    <div class="filter-options">
-      {#each Object.values(PLATFORM_TAGS) as platform}
-        <label class="filter-option">
-          <input 
-            type="checkbox" 
-            checked={selectedPlatforms.includes(platform)}
-            on:change={() => togglePlatform(platform)}
-          />
-          <span class="checkmark"></span>
-          <span class="label-text">{platform}</span>
-        </label>
-      {/each}
-    </div>
-  </div>
+	<div class="filter-group">
+		<div class="filter-header">
+			<h3 class="filter-title">
+				<span class="filter-icon">💻</span>
+				Platforms
+			</h3>
+			{#if selectedPlatforms.length > 0}
+				<button class="clear-btn" onclick={clearPlatforms}>Clear</button>
+			{/if}
+		</div>
 
-  <div class="filter-group">
-    <div class="filter-header">
-      <h3 class="filter-title">
-        <span class="filter-icon">🔧</span>
-        Frameworks
-      </h3>
-      {#if selectedFrameworks.length > 0}
-        <button class="clear-btn" on:click={clearFrameworks}>Clear</button>
-      {/if}
-    </div>
-    
-    <div class="filter-options">
-      {#each Object.values(FRAMEWORK_TAGS) as framework}
-        <label class="filter-option">
-          <input 
-            type="checkbox" 
-            checked={selectedFrameworks.includes(framework)}
-            on:change={() => toggleFramework(framework)}
-          />
-          <span class="checkmark"></span>
-          <span class="label-text">{framework}</span>
-        </label>
-      {/each}
-    </div>
-  </div>
+		<div class="filter-options">
+			{#each Object.values(PLATFORM_TAGS) as platform}
+				<label class="filter-option">
+					<input
+						type="checkbox"
+						checked={selectedPlatforms.includes(platform)}
+						onchange={() => togglePlatform(platform)}
+					/>
+					<span class="checkmark"></span>
+					<span class="label-text">{platform}</span>
+				</label>
+			{/each}
+		</div>
+	</div>
+
+	<div class="filter-group">
+		<div class="filter-header">
+			<h3 class="filter-title">
+				<span class="filter-icon">🔧</span>
+				Frameworks
+			</h3>
+			{#if selectedFrameworks.length > 0}
+				<button class="clear-btn" onclick={clearFrameworks}>Clear</button>
+			{/if}
+		</div>
+
+		<div class="filter-options">
+			{#each Object.values(FRAMEWORK_TAGS) as framework}
+				<label class="filter-option">
+					<input
+						type="checkbox"
+						checked={selectedFrameworks.includes(framework)}
+						onchange={() => toggleFramework(framework)}
+					/>
+					<span class="checkmark"></span>
+					<span class="label-text">{framework}</span>
+				</label>
+			{/each}
+		</div>
+	</div>
 </div>
 
 <style>
-  .filter-section {
-    display: flex;
-    flex-direction: column;
-    gap: 1.5rem;
-    padding: 1rem;
-    background: white;
-    border-radius: 8px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  }
+	.filter-section {
+		display: flex;
+		flex-direction: column;
+		gap: 1.5rem;
+		padding: 1rem;
+		background: white;
+		border-radius: 8px;
+		box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+	}
 
-  .filter-group {
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
-  }
+	.filter-group {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+	}
 
-  .filter-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-  }
+	.filter-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+	}
 
-  .filter-title {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    margin: 0;
-    font-size: 1rem;
-    font-weight: 600;
-    color: #374151;
-  }
+	.filter-title {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		margin: 0;
+		font-size: 1rem;
+		font-weight: 600;
+		color: #374151;
+	}
 
-  .filter-icon {
-    font-size: 1.2rem;
-  }
+	.filter-icon {
+		font-size: 1.2rem;
+	}
 
-  .clear-btn {
-    padding: 0.25rem 0.5rem;
-    font-size: 0.875rem;
-    color: #6b7280;
-    background: transparent;
-    border: 1px solid #d1d5db;
-    border-radius: 4px;
-    cursor: pointer;
-    transition: all 0.2s;
-  }
+	.clear-btn {
+		padding: 0.25rem 0.5rem;
+		font-size: 0.875rem;
+		color: #6b7280;
+		background: transparent;
+		border: 1px solid #d1d5db;
+		border-radius: 4px;
+		cursor: pointer;
+		transition: all 0.2s;
+	}
 
-  .clear-btn:hover {
-    background: #f9fafb;
-    color: #374151;
-  }
+	.clear-btn:hover {
+		background: #f9fafb;
+		color: #374151;
+	}
 
-  .filter-options {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-  }
+	.filter-options {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.5rem;
+	}
 
-  .filter-option {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.5rem;
-    background: #f9fafb;
-    border: 1px solid #e5e7eb;
-    border-radius: 6px;
-    cursor: pointer;
-    transition: all 0.2s;
-    font-size: 0.875rem;
-  }
+	.filter-option {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.5rem;
+		background: #f9fafb;
+		border: 1px solid #e5e7eb;
+		border-radius: 6px;
+		cursor: pointer;
+		transition: all 0.2s;
+		font-size: 0.875rem;
+	}
 
-  .filter-option:hover {
-    background: #f3f4f6;
-    border-color: #d1d5db;
-  }
+	.filter-option:hover {
+		background: #f3f4f6;
+		border-color: #d1d5db;
+	}
 
-  .filter-option input[type="checkbox"] {
-    appearance: none;
-    width: 16px;
-    height: 16px;
-    border: 2px solid #d1d5db;
-    border-radius: 3px;
-    position: relative;
-    cursor: pointer;
-  }
+	.filter-option input[type='checkbox'] {
+		appearance: none;
+		width: 16px;
+		height: 16px;
+		border: 2px solid #d1d5db;
+		border-radius: 3px;
+		position: relative;
+		cursor: pointer;
+	}
 
-  .filter-option input[type="checkbox"]:checked {
-    background: #3b82f6;
-    border-color: #3b82f6;
-  }
+	.filter-option input[type='checkbox']:checked {
+		background: #3b82f6;
+		border-color: #3b82f6;
+	}
 
-  .filter-option input[type="checkbox"]:checked::after {
-    content: '✓';
-    position: absolute;
-    top: -2px;
-    left: 1px;
-    color: white;
-    font-size: 12px;
-    font-weight: bold;
-  }
+	.filter-option input[type='checkbox']:checked::after {
+		content: '✓';
+		position: absolute;
+		top: -2px;
+		left: 1px;
+		color: white;
+		font-size: 12px;
+		font-weight: bold;
+	}
 
-  .label-text {
-    text-transform: capitalize;
-    color: #374151;
-  }
+	.label-text {
+		text-transform: capitalize;
+		color: #374151;
+	}
 
-  .filter-option:has(input:checked) {
-    background: #eff6ff;
-    border-color: #3b82f6;
-  }
+	.filter-option:has(input:checked) {
+		background: #eff6ff;
+		border-color: #3b82f6;
+	}
 
-  .filter-option:has(input:checked) .label-text {
-    color: #1d4ed8;
-    font-weight: 500;
-  }
+	.filter-option:has(input:checked) .label-text {
+		color: #1d4ed8;
+		font-weight: 500;
+	}
 </style>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -8,11 +8,17 @@
 	import type { Project } from '$shared/types/index.js';
 	import Fuse from 'fuse.js';
 
+	type GroupedProjects = {
+		groupName: string;
+		projects: Project[];
+	}[];
+
 	let { data } = $props();
 	let projects: Project[] = $state(data.projects);
 	let selectedMetadataFilters = $state<Record<string, string[]>>({});
 	let isLoading = $state(false);
 	let sortedProjects = $state<Project[]>([]);
+	let groupedProjects = $state<GroupedProjects>([]);
 	let searchQuery = $state('');
 
 	let fuse = $derived(new Fuse(projects, fuseOptions));
@@ -107,8 +113,9 @@
 		searchQuery = '';
 	}
 
-	function handleSortChange(newSortedProjects: Project[]) {
+	function handleSortChange(newSortedProjects: Project[], newGroupedProjects: GroupedProjects) {
 		sortedProjects = newSortedProjects;
+		groupedProjects = newGroupedProjects;
 	}
 
 	function handleSearchChange(query: string) {
@@ -142,7 +149,7 @@
 				{selectedMetadataFilters}
 				{updateMetadataFilter}
 			/>
-			
+
 			<ProjectSorting projects={filteredProjects} onSortChange={handleSortChange} />
 
 			{#if Object.values(selectedMetadataFilters).some((v) => v.length > 0) || searchQuery.trim()}
@@ -162,7 +169,20 @@
 				</div>
 			{/if}
 		</div>
-
-		<ProjectList projects={sortedProjects} />
+		{#if groupedProjects.length > 0}
+			{#each groupedProjects as group}
+				<div class="mb-8">
+					<h2 class="text-xl font-semibold text-gray-800 mb-4 pb-2 border-b border-gray-200">
+						{group.groupName}
+						<span class="text-sm font-normal text-gray-500 ml-2">
+							({group.projects.length} project{group.projects.length !== 1 ? 's' : ''})
+						</span>
+					</h2>
+					<ProjectList projects={group.projects} />
+				</div>
+			{/each}
+		{:else}
+			<ProjectList projects={sortedProjects} />
+		{/if}
 	{/if}
 </div>


### PR DESCRIPTION
This pull request introduces a new "Group by" feature to the project directory, allowing users to group projects by GitHub username or programming language in addition to sorting. It also includes UI improvements to project cards and filter components, and removes two projects from the backend data. The most important changes are outlined below.

**Project Directory Grouping and Sorting:**

* Added a "Group by" dropdown in `ProjectSorting.svelte` to allow grouping projects by GitHub username or programming language, updated sorting logic, and propagated grouped project data to the parent component. [[1]](diffhunk://#diff-407c19fe54dbc39ccfafa58d8b00b8958af3056717359a45de0447f93b6e3f86R6-R22) [[2]](diffhunk://#diff-407c19fe54dbc39ccfafa58d8b00b8958af3056717359a45de0447f93b6e3f86R47-R99) [[3]](diffhunk://#diff-407c19fe54dbc39ccfafa58d8b00b8958af3056717359a45de0447f93b6e3f86R108-R113) [[4]](diffhunk://#diff-407c19fe54dbc39ccfafa58d8b00b8958af3056717359a45de0447f93b6e3f86L67-R130) [[5]](diffhunk://#diff-407c19fe54dbc39ccfafa58d8b00b8958af3056717359a45de0447f93b6e3f86R155-R169) [[6]](diffhunk://#diff-277e5e66aac69da7616117de4cb91d3988aab163a62ebf7252f86fa6cf4b39eeR11-R21) [[7]](diffhunk://#diff-277e5e66aac69da7616117de4cb91d3988aab163a62ebf7252f86fa6cf4b39eeL110-R118)
* Updated the main page (`+page.svelte`) to display grouped projects with headings, falling back to a flat list if no grouping is selected.

**Project Card UI Enhancement:**

* Displayed the GitHub username on each project card by extracting it from the project URL. [[1]](diffhunk://#diff-cfb40c75c7ede5548a0ce32e0aa8283a5d14069995b891c28c07f8ea19ec10bcR9) [[2]](diffhunk://#diff-cfb40c75c7ede5548a0ce32e0aa8283a5d14069995b891c28c07f8ea19ec10bcR119-R123)

**Filter Component Consistency:**

* Standardized event handler attributes (`on:change` → `onchange`, `on:click` → `onclick`) and improved code style in `PlatformFrameworkFilters.svelte`. [[1]](diffhunk://#diff-252233721a9e65c33e30d9358869bb3e18395a03d62ed0ae7991b0e85c3a9f66L10-R18) [[2]](diffhunk://#diff-252233721a9e65c33e30d9358869bb3e18395a03d62ed0ae7991b0e85c3a9f66L41-R41) [[3]](diffhunk://#diff-252233721a9e65c33e30d9358869bb3e18395a03d62ed0ae7991b0e85c3a9f66L51-R51) [[4]](diffhunk://#diff-252233721a9e65c33e30d9358869bb3e18395a03d62ed0ae7991b0e85c3a9f66L67-R67) [[5]](diffhunk://#diff-252233721a9e65c33e30d9358869bb3e18395a03d62ed0ae7991b0e85c3a9f66L77-R77) [[6]](diffhunk://#diff-252233721a9e65c33e30d9358869bb3e18395a03d62ed0ae7991b0e85c3a9f66L164-R164) [[7]](diffhunk://#diff-252233721a9e65c33e30d9358869bb3e18395a03d62ed0ae7991b0e85c3a9f66L174-R179)

**Backend Data Update:**

* Removed the `engine_web-ifc` and `web-ifc-viewer` projects from `projects.json`. [[1]](diffhunk://#diff-6755039245c45e4dec256ee882107d59c091cecdeba954e3ae9461e7248c03c3L506-L530) [[2]](diffhunk://#diff-6755039245c45e4dec256ee882107d59c091cecdeba954e3ae9461e7248c03c3L576-L599)…username and language filters