### PR TITLE
Add friendly analytics

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -6,6 +6,26 @@
 	let { children } = $props();
 </script>
 
+<svelte:head>
+	<script>
+		var _paq = (window._paq = window._paq || []);
+		_paq.push(['setExcludedQueryParams', ['_gl', 'gad_source', 'wbraid', 'gad_campaignid']]);
+		_paq.push(['trackPageView']);
+		_paq.push(['enableLinkTracking']);
+		(function () {
+			var u = 'https://app.friendlyanalytics.ch/';
+			_paq.push(['setTrackerUrl', u + 'js/tracker.php']);
+			_paq.push(['setSiteId', '294']);
+			var d = document,
+				g = d.createElement('script'),
+				s = d.getElementsByTagName('script')[0];
+			g.async = true;
+			g.src = u + 'js/tracker.php';
+			s.parentNode.insertBefore(g, s);
+		})();
+	</script>
+</svelte:head>
+
 <div class="flex flex-col min-h-screen">
 	<Nav />
 


### PR DESCRIPTION
This pull request adds analytics tracking to the application by including a script for Friendly Analytics in the layout file. This will enable page view tracking and link tracking across the site.

**Analytics Integration:**

* Added a `<script>` block inside `<svelte:head>` in `+layout.svelte` to integrate Friendly Analytics, setting up page view and link tracking, and configuring tracker URL and site ID.