### PR TITLE
chore: migrate build-script allowlist to pnpm-workspace.yaml for pnpm 11

### DIFF
--- a/backend/pnpm-workspace.yaml
+++ b/backend/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  '@tailwindcss/oxide': true
+  esbuild: true


### PR DESCRIPTION
## What
Adds `pnpm-workspace.yaml` to `frontend/` and `backend/`, declaring the trusted native build dependencies (`esbuild`, `@tailwindcss/oxide`) via `allowBuilds`.

## Why
pnpm 11 stopped reading the build-script allowlist from the `package.json` `pnpm.onlyBuiltDependencies` field — it now reads it from `pnpm-workspace.yaml`. On pnpm 11, `pnpm install` prints:

> [WARN] The "pnpm" field in package.json is no longer read by pnpm. The following keys were ignored: "pnpm.onlyBuiltDependencies".

and defers the native build scripts (`esbuild`, `@tailwindcss/oxide`), so `pnpm run build` fails (Vite / Tailwind can't find their binaries) until a user manually runs `pnpm approve-builds`.

## Fix
Declaring the same trusted builds in `pnpm-workspace.yaml` (the location pnpm 11 reads) restores a clean, non-interactive `pnpm install` + `pnpm run build`. Verified locally on pnpm 11.9 / Node 25 — `pnpm install` runs the esbuild + oxide postinstalls and `pnpm run build` completes and writes to `public/`.

Config only — no runtime or dependency-version changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)